### PR TITLE
minor improvements to the projects page

### DIFF
--- a/src/projects.njk
+++ b/src/projects.njk
@@ -15,15 +15,14 @@ bigLogo: false
         <a
           href="mailto:contact@osfw.foundation"
           class="inline-link color-primary"
-          >contact@osfw.foundation 
-        </a>.
+          >contact@osfw.foundation</a>.
       </p>
       <div class="wrapper | flow flow-space-800">
         <div class="flow">
           <h4>Supported By Us</h4>
           <ul role="list" class="flow flow-space-600">
 
-            {% for item in collections.projects %}
+            {% for item in collections.projects | sort(false, false, 'data.title') %}
               {% if item.data.supportedByUs %}
 
                 <li>
@@ -40,7 +39,7 @@ bigLogo: false
                       {% endif %}
 
                       <dl class="">
-                        <dd>"{{ item.data.summary }}"</dd>
+                        <dd>{{ item.data.summary }}</dd>
                       </dl>
                     </div>
                     <a class="project-cards__link" target="_blank" href="{{ item.data.link }}"></a>
@@ -56,7 +55,7 @@ bigLogo: false
           <h4>Not Affilated Projects</h4>
           <ul role="list" class="flow flow-space-600">
 
-            {% for item in collections.projects %}
+            {% for item in collections.projects | sort(false, false, 'data.title') %}
               {% if not item.data.supportedByUs %}
 
                 <li>
@@ -73,7 +72,7 @@ bigLogo: false
                       {% endif %}
 
                       <dl class="">
-                        <dd>"{{ item.data.summary }}"</dd>
+                        <dd>{{ item.data.summary }}</dd>
                       </dl>
                     </div>
                     <a class="project-cards__link" target="_blank" href="{{ item.data.link }}"></a>

--- a/src/projects/converged-security-suite.md
+++ b/src/projects/converged-security-suite.md
@@ -2,7 +2,7 @@
 title: "converged-security-suite"
 img:
   src: "../images/projects/css.svg"
-summary: " The Converged Security Suite (CSS) is a set of open-source tooling to provision and test security related features in the firmware. The CSS implements all necessary tools for Intel platform security features."
+summary: "The Converged Security Suite (CSS) is a set of open-source tooling to provision and test security related features in the firmware. The CSS implements all necessary tools for Intel platform security features."
 link: "https://github.com/9elements/converged-security-suite"
 supportedByUs: true
 ---

--- a/src/projects/oscar.md
+++ b/src/projects/oscar.md
@@ -3,7 +3,7 @@ title: "go-tcg-storage"
 img:
   src: "../images/projects/oscar.svg"
   alt: "no logo yet :)"
-summary: "The go-tcg-storage is a go library for interfacing TCG Storage and Security Subsystem Class (SSC) functions on storage devices. Currently it supports the following TCG standards: Core, Opal 2.0, Enterprise and Ruby"
+summary: "The go-tcg-storage is a go library for interfacing TCG Storage and Security Subsystem Class (SSC) functions on storage devices. Currently it supports the following TCG standards: Core, Opal 2.0, Enterprise and Ruby."
 link: "https://github.com/open-source-firmware/go-tcg-storage"
 supportedByUs: true
 ---


### PR DESCRIPTION
* Don't quote the project descriptions. They are not quotes.
* Add missing period to go-tcg-storage description.
* Remove leading whitespace from css desc.
* Sort the project list for consistent order.