### PR TITLE
Fix Mastodon verification label

### DIFF
--- a/src/_includes/layouts/base.html
+++ b/src/_includes/layouts/base.html
@@ -6,6 +6,7 @@
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta http-equiv="X-UA-Compatible" content="ie=edge"/>
+    <a rel="me" href="https://fosstodon.org/@osff" />
     <script>
       document
         .documentElement

--- a/src/_includes/partials/site-head.html
+++ b/src/_includes/partials/site-head.html
@@ -6,7 +6,6 @@
   </h1>
 </div>
 <header role="banner" class="header">
-  <a rel="me" href="https://fosstodon.org/@osff" />
   <nav class="main-nav flow" aria-label="main">
     <ul class="main-nav__list">
       {% for item in navigation.items %}


### PR DESCRIPTION
The verification doesn't work. So move the related HTML to the `<head>`
section since this worked elsewhere.